### PR TITLE
Lazy load model files

### DIFF
--- a/khmernltk/pos_tag/__init__.py
+++ b/khmernltk/pos_tag/__init__.py
@@ -8,7 +8,7 @@ from khmernltk.utils.file_utils import load_model
 
 # sklearn_crf_pos_alt_0.9849.sav
 model_path = os.path.join(os.path.dirname(__file__), "sklearn_crf_pos_alt_0.9846.sav")
-crf_model = load_model(model_path)
+crf_model = None
 
 
 def pos_tag(text: str) -> List[Tuple[str, str]]:
@@ -20,6 +20,10 @@ def pos_tag(text: str) -> List[Tuple[str, str]]:
     Returns:
         List[Tuple[str, str]]: List of tuple (token, pos tag)
     """
+    global crf_model
+    if crf_model is None:
+        crf_model = load_model(model_path)
+
     text = cleanup_str(text)
     tokens = word_tokenize.word_tokenize(text, return_tokens=True)
     features = create_word_features(tokens)

--- a/khmernltk/word_tokenize/__init__.py
+++ b/khmernltk/word_tokenize/__init__.py
@@ -8,7 +8,7 @@ from khmernltk.word_tokenize.features import create_kcc_features
 
 # sklearn_crf_ner_alt_0.9725.sav / sklearn_crf_ner_10000.sav
 model_path = os.path.join(os.path.dirname(__file__), "sklearn_crf_ner_10000.sav")
-crf_model = load_model(model_path)
+crf_model = None
 
 
 def word_tokenize(text: str, separator: str = "-", return_tokens: bool = True) -> Union[List, str]:
@@ -22,6 +22,10 @@ def word_tokenize(text: str, separator: str = "-", return_tokens: bool = True) -
     Returns:
         Union[List, str]: Tokens or tokenized text, separated by the separator
     """
+    global crf_model
+    if crf_model is None:
+        crf_model = load_model(model_path)
+
     text = cleanup_str(text)
     skcc = seg_kcc(text)
 


### PR DESCRIPTION
Solves #5.

The model files are loaded only when needed (functions for tokenization and POS tagging are invoked). The model files are cached as global variables so that subsequent calls after the first invocation to functions would not load model files repetitively.

No breaking changes should be introduced, as I don't suppose that users would use the loaded model file directly instead of through `khmernltk.word_tokenize` and `khmernltk.pos_tag`...